### PR TITLE
codecvt removal

### DIFF
--- a/latebros/api_set.cpp
+++ b/latebros/api_set.cpp
@@ -40,7 +40,7 @@ bool api_set::query(std::wstring& name) const
 	// SEARCH FOR ANY ENTRIES OF OUR PROXY DLL
 	const auto iter = std::find_if(this->schema.begin(), this->schema.end(), [&](const map_api_schema::value_type& val)
 	{
-		return name.find(val.first) != name.npos;
+		return std::search(name.begin(), name.end(), val.first.begin(), val.first.end()) != name.end();
 	});
 
 	if (iter != this->schema.end() && !iter->second.empty()) // FOUND
@@ -50,4 +50,15 @@ bool api_set::query(std::wstring& name) const
 	}
 
 	return false;
+}
+
+bool api_set::query(std::string& name) const
+{
+	std::wstring wide_name(name.begin(), name.end());
+
+	if (!query(wide_name))
+		return false;
+
+	name.assign(wide_name.begin(), wide_name.end());
+	return true;
 }

--- a/latebros/api_set.hpp
+++ b/latebros/api_set.hpp
@@ -68,6 +68,7 @@ class api_set
 public:
 	api_set();
 	bool query(std::wstring& name) const;
+	bool query(std::string& name) const;
 private:
 	map_api_schema schema;
 };

--- a/latebros/logger.hpp
+++ b/latebros/logger.hpp
@@ -1,13 +1,23 @@
 #pragma once
 #include "stdafx.h"
+#include <system_error>
 
 namespace logger
 {
-	inline void log(const std::string& message)
+	inline void log(const char* message)
 	{
 		std::cout << "[+] " << message << std::endl;
 	}
-	inline void log_error(const std::string& message)
+
+	inline void log_win_error(const char* cause)
+	{
+		const auto ec = std::error_code(static_cast<int>(GetLastError()), std::system_category());
+		std::cout << "[!] code: " << std::hex << ec.value()
+				<< " message: " << ec.message()
+				<< " what: " << cause << '\n';
+	}
+
+	inline void log_error(const char* message)
 	{
 		std::cout << "[!] " << message << std::endl;
 	}

--- a/latebros/main.cpp
+++ b/latebros/main.cpp
@@ -37,25 +37,20 @@ int main()
 
 	for (const auto& process_name : { "taskmgr.exe", "processhacker.exe", "regedit.exe"/*, "explorer.exe"*/ })
 	{
-		auto process_list = process::get_all_from_name(process_name);
+		auto process_list = get_all_processes(process_name);
 
 		if (process_list.empty()) // NO PROCESSES FOUND
+		{
+			logger::log_formatted("process not running or elevation insufficient", process_name);
 			continue;
+		}
 
 		// ENUMERATE ALL PROCESSES
-		for (auto id : process_list)
+		for (auto& proc : process_list)
 		{
 			logger::log_formatted("Target Process", process_name);
 
 			// MAP LITTLEBRO INTO TARGET PROCESS
-			auto proc = process(id, PROCESS_ALL_ACCESS);
-
-			if (!proc)
-			{
-				logger::log_error("Non-sufficient elevation, aborting");
-				continue;
-			}
-
 			const auto littlebro = injection::manualmap(proc).inject(littlebro_buffer);
 			auto hooks = remote_detours{ proc, littlebro };
 			// HOOK FUNCTIONS

--- a/latebros/manualmap.cpp
+++ b/latebros/manualmap.cpp
@@ -92,16 +92,12 @@ void injection::manualmap::relocate_image_by_delta(map_ctx& ctx)
 
 void injection::manualmap::fix_import_table(map_ctx& ctx)
 {
-	wstring_converter converter;
 	api_set api_schema;
 
 	for (const auto&[tmp_name, functions] : ctx.pe.get_imports(ctx.local_image))
 	{
 		auto module_name = tmp_name;
-
-		std::wstring wide_module_name = converter.from_bytes(module_name.c_str());
-		if (api_schema.query(wide_module_name))
-			module_name = converter.to_bytes(wide_module_name);
+		api_schema.query(module_name);
 
 		auto module_handle = find_or_map_dependency(module_name);
 		if (!module_handle)

--- a/latebros/manualmap.cpp
+++ b/latebros/manualmap.cpp
@@ -21,7 +21,6 @@ uintptr_t injection::manualmap::inject(const std::vector<uint8_t>& buffer)
 
 bool injection::manualmap::map_image(map_ctx& ctx)
 {
-
 	auto section = memory_section(PAGE_EXECUTE_READWRITE, ctx.pe.get_optional_header().SizeOfImage);
 
 	if (!section)
@@ -31,7 +30,7 @@ bool injection::manualmap::map_image(map_ctx& ctx)
 	}
 
 	// MAP SECTION INTO BOTH LOCAL AND REMOTE PROCESS
-	ctx.local_image = process::current_process().map(section);
+	ctx.local_image = get_current_process().map(section);
 	ctx.remote_image = this->process.map(section);
 
 	if (!ctx.local_image || !ctx.remote_image)

--- a/latebros/manualmap.hpp
+++ b/latebros/manualmap.hpp
@@ -16,8 +16,6 @@ struct map_ctx
 		image_name(new_image_name), pe(new_buffer) {}
 };
 
-// DEPRECATED - TODO
-using wstring_converter = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>;
 using module_list = std::unordered_map<std::string, uintptr_t>;
 
 namespace injection

--- a/latebros/process.cpp
+++ b/latebros/process.cpp
@@ -193,8 +193,7 @@ uintptr_t process::get_import(const std::string& module_name, const std::string&
 		if(current_module_name.empty())
 			continue;
 
-		if(!api_schema.query(current_module_name))
-			continue;
+		api_schema.query(current_module_name);
 
 		// LOWERCASE FOR MORE CONSISTENT COMPARISON RESULTS
 		std::transform(current_module_name.begin(), current_module_name.end(), current_module_name.begin(), ::tolower);

--- a/latebros/process.cpp
+++ b/latebros/process.cpp
@@ -23,11 +23,11 @@ process process::current_process()
 	return process(reinterpret_cast<HANDLE>(GetCurrentProcess()));
 }
 
-std::vector<uint32_t> process::get_all_from_name(const std::string& process_name)
+std::vector<std::uint32_t> process::get_all_from_name(const std::string& process_name)
 {
-	std::vector<uint32_t> processes;
+	std::vector<std::uint32_t> processes;
 
-	DWORD process_list[516], bytes_needed;
+	unsigned long process_list[516], bytes_needed;
 	if (EnumProcesses(process_list, sizeof(process_list), &bytes_needed))
 	{
 		for (size_t index = 0; index < bytes_needed / sizeof(uint32_t); index++)
@@ -41,6 +41,8 @@ std::vector<uint32_t> process::get_all_from_name(const std::string& process_name
 				processes.emplace_back(process_list[index]);
 		}
 	}
+	else
+		logger::log_win_error("EnumProcesses");
 
 	return processes;
 }
@@ -157,10 +159,14 @@ uintptr_t process::get_base_address() const
 
 std::string process::get_name() const
 {
-	char buffer[MAX_PATH];
-	GetModuleBaseNameA(handle.get(), nullptr, buffer, MAX_PATH);
-
-	auto name = std::string(buffer);
+	std::string name;
+	name.resize(MAX_PATH);
+	auto len = GetModuleBaseNameA(handle.get(), nullptr, name.data(), MAX_PATH);
+	if(!len) {
+		logger::log_win_error("process::get_name->GetModuleBaseNameA");
+		return {};
+	}
+	name.resize(len);
 
 	std::transform(name.begin(), name.end(), name.begin(), ::tolower);
 
@@ -179,22 +185,19 @@ uintptr_t process::get_import(const std::string& module_name, const std::string&
 	auto import_table_address = image_base + nt_header.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT].VirtualAddress;
 
 	api_set api_schema;
-	wstring_converter converter;
 
 	this->read_memory(&import_table, import_table_address);
 	for (; import_table.Name; import_table_address += sizeof(IMAGE_IMPORT_DESCRIPTOR), this->read_memory(&import_table, import_table_address))
 	{
-		char name_buffer[100];
-		this->read_raw_memory(name_buffer, image_base + import_table.Name, sizeof(name_buffer));
-		std::string current_module_name = name_buffer;
+		auto current_module_name = read_string(image_base + import_table.Name, 128);
+		if(current_module_name.empty())
+			continue;
 
-		std::wstring wide_module_name = converter.from_bytes(current_module_name.c_str());
-		if (api_schema.query(wide_module_name))
-			current_module_name = converter.to_bytes(wide_module_name);
+		if(!api_schema.query(current_module_name))
+			continue;
 
 		// LOWERCASE FOR MORE CONSISTENT COMPARISON RESULTS
 		std::transform(current_module_name.begin(), current_module_name.end(), current_module_name.begin(), ::tolower);
-
 		if (module_name != current_module_name)
 			continue;
 

--- a/latebros/process.hpp
+++ b/latebros/process.hpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "memory_section.hpp"
 
-using wstring_converter = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>;
+//using wstring_converter = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>;
 
 class process
 {
@@ -29,7 +29,7 @@ public:
 	uintptr_t map(memory_section& section);
 
 	template <class T>
-	inline uintptr_t allocate_and_write(const T& buffer)
+	uintptr_t allocate_and_write(const T& buffer)
 	{
 		auto buffer_pointer = allocate(buffer);
 		write_memory(buffer, buffer_pointer);
@@ -37,36 +37,36 @@ public:
 	}
 
 	template <class T>
-	inline uintptr_t allocate()
+	uintptr_t allocate()
 	{
 		return raw_allocate(sizeof(T));
 	}
 
 	template<class T>
-	inline bool read_memory(T* buffer, const uintptr_t address) const
+	bool read_memory(T* buffer, const uintptr_t address) const
 	{
 		return read_raw_memory(buffer, address, sizeof(T));
 	}
 
 	template<class T>
-	inline bool write_memory(const T& buffer, const uintptr_t address) const
+	bool write_memory(const T& buffer, const uintptr_t address) const
 	{
 		return write_raw_memory(&buffer, sizeof(T), address);
 	}
 
-	template<class T>
-	bool write_memory_safe(const T& buffer, const uintptr_t address) const
+	std::string read_string(std::uintptr_t address, std::size_t max_chars) const
 	{
-		uint32_t old_protect;
-		auto result = this->virtual_protect(address, PAGE_EXECUTE_READWRITE, &old_protect);
-		if(result)
-			return false;
-		
-		result = write_raw_memory(&buffer, sizeof(T), address);
-		this->virtual_protect(old_protect, PAGE_EXECUTE_READWRITE, &old_protect);
+		std::string s;
+		s.resize(max_chars);
+		if(read_raw_memory(s.data(), address, max_chars))
+			if(auto it = s.find('\0'); it != std::string::npos) {
+				s.resize(it);
+				return s;
+			}
 
-		return result;
+		return {};
 	}
+
 #pragma endregion
 
 #pragma region Information

--- a/latebros/process.hpp
+++ b/latebros/process.hpp
@@ -2,7 +2,13 @@
 #include "stdafx.h"
 #include "memory_section.hpp"
 
-//using wstring_converter = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>;
+class process;
+
+process get_current_process();
+
+std::vector<process> get_all_processes();
+
+std::vector<process> get_all_processes(const std::string& process_name);
 
 class process
 {
@@ -10,13 +16,7 @@ public:
 	process(uint32_t id, DWORD desired_access);
 	process(HANDLE handle) : handle(handle) {}
 
-	explicit operator bool();
-
-#pragma region Statics
-	static process current_process();
-	static std::vector<uint32_t> get_all_from_name(const std::string& process_name);
-	static std::vector<uint32_t> get_all();
-#pragma endregion
+	explicit operator bool() const;
 
 #pragma region Memory
 	MEMORY_BASIC_INFORMATION virtual_query(const uintptr_t address);

--- a/latebros/stdafx.h
+++ b/latebros/stdafx.h
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <iterator>
 #include <fstream>
-#include <codecvt>
 #include <memory>
 #include <locale>
 #include <random>


### PR DESCRIPTION
MSVC now has deprecation warnings so I decided to remove codecvt entirely.
This fix might break if there are some imports that actually use unicode names...